### PR TITLE
Proposal way to fix the + selection issue

### DIFF
--- a/graphtool.js
+++ b/graphtool.js
@@ -1544,8 +1544,10 @@ d3.json(typeof PHONE_BOOK !== "undefined" ? PHONE_BOOK
             .attr("class", "phone-item-add")
             .on("click", p => {
             //  Commented out this for consistent mobile functionality, but not sure what it was for.
-              d3.event.stopPropagation();
+                d3.event.stopPropagation();
                 showPhone(p, 0);
+                let panelsContainer = document.querySelector("main.main");
+                panelsContainer.setAttribute("data-focused-panel","primary");
             })
             
 
@@ -1866,6 +1868,7 @@ function setFocusedPanel() {
         let thingClicked = e.target;
         
         if ( thingClicked.matches(".phone-item, .phone-item span, .phone-item-add") ) {
+            
             panelsContainer.setAttribute("data-focused-panel","primary");
             e.stopPropagation();
         }


### PR DESCRIPTION
Like the title said, you said we can move this to #showPhone() later on, but currently this is my workaround.

Need more debugging works to see if it truly works or not. Tho this seem more like a hack
The reason why currently the graph didn't collapse is due to #setFocusedPanel cannot track .phone-list-add, which seem to be served inside .item-phone which seem null upon initiation.
Don't ask me why it is null -_-

Why removing e.stopPropagation() seem to work?
Turns out the click event would be bounded to .item-phone so it fires that event instead
Again, don't ask me how it worked like that, it just works. 
This is the best I can try to give out my explanation/speculation despite everything seem to work and workn't at the same time. Someone should correct me on this since my JS skill can make my interpretation really misleading

The current solution is done by firing the action right after clicking the button, since we sure know .item-phone and .item-phone-add is initialized by then, also helps that this will guarantee it is fired when we clicked the button -_-

