### PR TITLE
Push and Pull PEQ values from selected (Fiio for now) devices directly within Squiq.link

### DIFF
--- a/fiioUsbHidHandler.js
+++ b/fiioUsbHidHandler.js
@@ -1,0 +1,289 @@
+//
+// Copyright 2024 : Pragmatic Audio
+//
+// Define the shared logic for JadeAudio / FiiO devices - Each manufacturer will have slightly
+// different code so best to each have a separate 'module'
+
+const PEQ_FILTER_COUNT=  24;
+const PEQ_GLOBAL_GAIN = 23;
+const PEQ_FILTER_PARAMS = 21;
+const PEQ_PRESET_SWITCH = 22;
+const MAX_FILTERS = 5;  // JA11 only has 5
+
+window.fiioUsbHID = {
+    connect: async function(device) {
+        try {
+            await device.open();
+            console.log("FiiO Device connected");
+        } catch (error) {
+            console.error("Failed to connect to FiiO Device:", error);
+        }
+    },
+    pushToDevice: async function(device, slot, preamp, filters) {
+        try {
+            async function setPeqParams(device, slot, fc, gain, q, filterType) {
+
+                // Convert frequency to high and low bytes
+                const [frequencyHigh, frequencyLow] = splitUnsignedValue(fc);
+
+                // Convert gain to high and low bytes
+                const gainValue = Math.round(gain * 10); // Multiply gain by 10 to restore original scaling
+                const [gainHigh, gainLow] = splitSignedValue(gainValue);
+                // Convert qFactor to high and low bytes
+                const qFactorValue = Math.round(q * 100); // Multiply q by 100 to restore original scaling
+                const [qFactorHigh, qFactorLow] = splitUnsignedValue(qFactorValue);
+
+                const packet = [170, 10, 0, 0, PEQ_FILTER_PARAMS, 8, slot, gainHigh, gainLow, frequencyHigh, frequencyLow, qFactorHigh, qFactorLow, filterType, 0, 238];
+                const data = new Uint8Array(packet);
+                const reportId = device.collections[0].outputReports[0].reportId;
+                console.log("setPeqParams() reportId", reportId, "Send data:", data);
+                await device.sendReport(reportId, data);
+            }
+
+            async function setPresetPeq(device, presetId) {
+
+                const packet = [170, 10, 0, 0, PEQ_PRESET_SWITCH, 1, presetId, 0, 238];
+                const data = new Uint8Array(packet);
+                const reportId = device.collections[0].outputReports[0].reportId;
+                console.log("setPresetPeq() reportId", reportId, "Send data:", data);
+                await device.sendReport(reportId, data);
+            }
+
+            async function setGlobalGain(device, gain) {
+                let globalGain = Math.round(gain * 100); // Multiply by 100 and round
+
+                const gainBytes = toBytePair(globalGain);
+                const packet = [170, 10, 0, 0, PEQ_GLOBAL_GAIN, 2, gainBytes[0], gainBytes[1], 0, 238];
+                const data = new Uint8Array(packet);
+                const reportId = device.collections[0].outputReports[0].reportId;
+                console.log("setGlobalGain() reportId", reportId, "Send data:", data);
+                await device.sendReport(reportId, data);
+            }
+
+            async function setPeqCounter(device, counter) {
+
+                const packet = [170, 10, 0, 0, PEQ_FILTER_COUNT, 1, counter, 0, 238];
+                const data = new Uint8Array(packet);
+                const reportId = device.collections[0].outputReports[0].reportId;
+                console.log("setSavePeq() reportId", reportId, "Send data:", data);
+                await device.sendReport(reportId, data);
+            }
+
+            function convertFromFilterType(filterType) {
+                switch (filterType) {
+                    case "PK":
+                        return 0
+                    case "LSQ":
+                        return 1
+                    case "HSQ":
+                        return 2
+                    default:
+                        return 0
+                }
+            }
+
+
+            setGlobalGain(device, preamp );
+
+            let maxFiltersToUse = filters.length > MAX_FILTERS ? MAX_FILTERS : filters.length;
+            setPeqCounter(device, maxFiltersToUse);
+
+            for (filterIdx = 0; filterIdx < maxFiltersToUse; filterIdx++) {
+                setPeqParams(device, filterIdx,
+                    filters[filterIdx].freq, filters[filterIdx].gain,
+                    filters[filterIdx].q, convertFromFilterType(filters[filterIdx].type));
+            }
+
+        } catch (error) {
+            console.error("Failed to push data to FiiO Device:", error);
+        }
+    },
+    pullFromDevice: async function(device, slot) {
+        let filters = []; // Array to accumulate filter settings
+        let peqCount = 0;
+        let globalGain = 0;
+        let filtersPopulated = false;
+
+        console.log("Requested EQ profile data from the device.");
+
+        // Handle the input report when data is received from the device
+        device.oninputreport = async (event) => {
+            console.log("oninputreport event:", event);
+            const data = new Uint8Array(event.data.buffer);
+            console.log("Data received:", data);
+
+            if (data.length > 0) {
+                parseHIDInput(data);
+            }
+        }
+
+        // Function to parse the input data
+        function parseHIDInput(data) {
+            if (data[0] == 187 && data[1] == 11) {
+                switch (data[4]) {
+                    case PEQ_FILTER_COUNT:
+                        handlePeqCounter(data);
+                        break;
+                    case PEQ_FILTER_PARAMS:
+                        handlePeqParams(data);
+                        break;
+                    case PEQ_GLOBAL_GAIN:
+                        handleGlobalGain(data);
+                        break;
+                    case PEQ_PRESET_SWITCH:
+                        handleEqPreset(data[6]);
+                        break;
+                    default:
+                        console.log("Unhandled data type.");
+                }
+            }
+
+            let hexString = data.reduce((str, byte) => str + byte.toString(16).padStart(2, "0").toUpperCase() + " ", "");
+            console.log("hexstr=", hexString);
+        }
+
+        function getGlobalGain(device) {
+            const packet = [187, 11, 0, 0, PEQ_GLOBAL_GAIN, 0, 0, 238];
+            const data = new Uint8Array(packet);
+            console.log("getGlobalGain() Send data:", data);
+            const reportId = device.collections[0].outputReports[0].reportId;
+            device.sendReport(reportId, data);
+        }
+
+        function getPeqCounter(device) {
+            const packet = [187, 11, 0, 0, PEQ_FILTER_COUNT, 0, 0, 238];
+            const data = new Uint8Array(packet);
+            console.log("getPeqCounter() Send data:", data);
+            const reportId = device.collections[0].outputReports[0].reportId;
+            device.sendReport(reportId, data);
+        }
+
+        function getPeqParams(device, slotId) {
+            const packet = [187, 11, 0, 0, PEQ_FILTER_PARAMS, 1, slotId, 0, 238];
+            const data = new Uint8Array(packet);
+            console.log("getPeqParams() Send data:", data);
+            const reportId = device.collections[0].outputReports[0].reportId;
+            device.sendReport(reportId, data);
+        }
+
+        function handleGlobalGain(data) {
+            globalGain = combineBytes(data[7], data[6]) / 100;
+        }
+
+        function handlePeqCounter(data) {
+            peqCount = data[6];
+            console.log("***********oninputreport peq counter=", peqCount);
+            if (peqCount > 0) {
+                processPeqCount();
+            }
+        }
+
+        function handleEqPreset(value) {
+            // Handle other types of data
+            console.log("EQ Preset: ", value);
+        }
+
+        function processPeqCount() {
+            console.log("PEQ Counter:", peqCount);
+
+            // Fetch individual PEQ settings based on count
+            for (let i = 0; i < peqCount; i++) {
+                getPeqParams(device, i);
+            }
+        }
+
+        function convertToFilterType(datum) {
+            switch (datum) {
+                case 0:
+                    return "PK"
+                case 1:
+                    return "LSQ"
+                case 2:
+                    return "HSQ"
+                default:
+                    return "PK"
+            }
+        }
+
+        function handlePeqParams(data) {
+            // Extract filter details and store them in the filters array
+            const gain = signedCombine(data[7], data[8]) / 10;
+            const frequency = (data[9] << 8) | data[10];
+            const qFactor = ((data[11] << 8) | data[12]) / 100 || 1;
+            const filterType = convertToFilterType(data[13]);
+
+            console.log("Filter Details - Gain: ", gain, " Frequency: ", frequency, " Q: ", qFactor, " Type: ", filterType);
+
+            // Store the filter information
+            filters.push({
+                type: filterType,
+                freq: frequency,
+                q: qFactor,
+                gain: gain,
+                disabled: false // Adjust this depending on your logic
+            });
+
+            if (filters.length >= peqCount) {
+                filtersPopulated = true; // Mark filters as fully populated
+            }
+        }
+
+        // Promise that resolves when filters are populated or times out after 10 seconds
+        const waitForFilters = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                if (!filtersPopulated) {
+                    console.log("Timeout reached before filters were fully populated.");
+                }
+                resolve(filters); // Return filters even if timeout occurs
+            }, 10000); // 10 seconds timeout
+
+            // Polling to check if filters are populated
+            const checkFilters = setInterval(() => {
+                if (filtersPopulated) {
+                    clearTimeout(timeout); // Clear timeout if filters are populated
+                    clearInterval(checkFilters); // Stop polling
+                    resolve(filters); // Return the populated filters
+                }
+            }, 100); // Poll every 100ms
+        });
+
+        // Start the process by requesting the PEQ counter and global gain
+        getPeqCounter(device);
+        getGlobalGain(device);
+
+        // Wait for filters to be populated or timeout
+        return await waitForFilters;
+    }
+};
+
+function toBytePair(value) {
+    return [
+        value & 0xFF,        // Least Significant Byte
+        (value & 0xFF00) >> 8  // Most Significant Byte
+    ];
+}
+
+function combineBytes(lowByte, highByte) {
+    return (highByte << 8) | lowByte;
+}
+
+function signedCombine(highByte, lowByte) {
+    const combined = (highByte << 8) | lowByte;
+    return combined > 32767 ? combined - 65536 : combined;
+}
+
+// Function to split a signed 16-bit integer into two bytes
+function splitSignedValue(value) {
+    let signedValue = value < 0 ? value + 65536 : value; // Convert signed value to unsigned 16-bit
+    const highByte = (signedValue >> 8) & 0xFF; // Extract the high byte
+    const lowByte = signedValue & 0xFF;         // Extract the low byte
+    return [highByte, lowByte];
+}
+
+// Function to split an unsigned 16-bit integer (for frequency and qFactor)
+function splitUnsignedValue(value) {
+    const highByte = (value >> 8) & 0xFF; // Extract the high byte
+    const lowByte = value & 0xFF;         // Extract the low byte
+    return [highByte, lowByte];
+}
+

--- a/graph.html
+++ b/graph.html
@@ -32,6 +32,8 @@
         <script src="equalizer.js"></script>
         <script src="listAugment.js"></script>
         <script src="saveSvgAsPng.js"></script>
+        <script src="fiioUsbHidHandler.js"></script>
+        <script src="usbHidConnector.js"></script>
         <script src="graphtool.js"></script>
     </body>
 </html>

--- a/graphtool.js
+++ b/graphtool.js
@@ -2774,8 +2774,6 @@ function addExtra() {
                     if (filters.length > 0) {
                         filtersToElem(filters);
                         applyEQ();
-                    } else {
-                        alert("no filter found.");
                     }
                 });
             }

--- a/graphtool.js
+++ b/graphtool.js
@@ -1,3 +1,4 @@
+
 let doc = d3.select(".graphtool");
 doc.html(`
   <svg style="display: none;">
@@ -181,6 +182,8 @@ doc.html(`
                 <button class="readme">Readme</button>
                 <button class="import-filters">Import</button>
                 <button class="export-filters">Export</button>
+                <button hidden="true" class="pull-filters-fromdevice">Pull From Device</button>
+                <button hidden="true" class="push-filters-todevice">Push To Device</button>
                 <button class="export-graphic-filters">Export Graphic EQ (For Wavelet)</button>
               </div>
               <a style="display: none" id="file-filters-export"></a>
@@ -2317,6 +2320,7 @@ function blurFocus() {
 }
 blurFocus();
 
+
 // Add extra feature
 function addExtra() {
     let extraButton = document.querySelector("div.select > div.selector-tabs > button.extra");
@@ -2732,7 +2736,77 @@ function addExtra() {
             toneGeneratorPlayButton.innerText = "Stop";
         }
     });
-    
+
+
+    function updateButtonText(device) {
+        const pushButton = document.querySelector('.push-filters-todevice');
+        const pullButton = document.querySelector('.pull-filters-fromdevice');
+        if (device === undefined) {
+            // Remove "device" in the push and pull buttons
+            pushButton.textContent = "Push To Device";
+            pullButton.textContent = "Pull From Device";
+        } else {
+            // Remove "device" in the push and pull buttons
+            pushButton.textContent = pushButton.textContent.replace("To Device", device.model);
+            pullButton.textContent = pullButton.textContent.replace("From Device", device.model);
+        }
+    }
+
+    if (UsbHIDConnector.isWebHIDSupported()) {
+
+        // unhide the 2 new buttons
+        document.querySelector('.pull-filters-fromdevice').hidden = false;
+        document.querySelector('.push-filters-todevice').hidden = false;
+
+        // Add Event listener for "Pull From Device" button
+        document.querySelector('.pull-filters-fromdevice').addEventListener('click', async () => {
+
+            let connectedDevice = await UsbHIDConnector.getDeviceConnected();
+            // Update Push / Pull Button text to show device name
+            updateButtonText(connectedDevice);
+
+            if (typeof connectedDevice !== "undefined") {
+
+                // Proceed with pulling filters from the connected device
+                console.log('Pulling filters from device...');
+                UsbHIDConnector.pullFromDevice(connectedDevice, 0).then(filters => {
+                    // Update the filters now from the device
+                    if (filters.length > 0) {
+                        filtersToElem(filters);
+                        applyEQ();
+                    } else {
+                        alert("no filter found.");
+                    }
+                });
+            }
+        });
+
+        // Event listener for "Push To Device" button
+        document.querySelector('.push-filters-todevice').addEventListener('click', async () => {
+            let connectedDevice = await UsbHIDConnector.getDeviceConnected();
+            // Update Push / Pull Button text to show device name
+            updateButtonText(connectedDevice);
+
+            if (connectedDevice != null) {
+                // Proceed with pushing filters to the connected device
+                console.log('Pushing filters to device...');
+
+                let phoneSelected = eqPhoneSelect.value;
+                let phoneObj = phoneSelected && activePhones.filter(
+                    p => p.fullName == phoneSelected && p.eq)[0];
+                let filters = elemToFilters(true);
+                if (!phoneObj || !filters.length) {
+                    alert("Please select model and add at least one filter before push to device.");
+                    return;
+                }
+                let preamp = Equalizer.calc_preamp(
+                    phoneObj.rawChannels.filter(c => c)[0],
+                    phoneObj.eq.rawChannels.filter(c => c)[0]);
+
+                await UsbHIDConnector.pushToDevice(connectedDevice, 0, preamp, filters);
+            }
+        });
+    }
 }
 addExtra();
 
@@ -3257,3 +3331,30 @@ function userConfigApplyNormalization() {
     
     userConfigApplicationActive = 0;
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+
+    // Function to detect if the browser is Chrome-based
+    function isChromeBasedBrowser() {
+        const userAgent = navigator.userAgent;
+
+        // Check for Chrome, Brave, Bing, Arc in the user agent string
+        const isChrome = userAgent.includes("Chrome") && !userAgent.includes("Edge") && !userAgent.includes("OPR") && !userAgent.includes("Edg");
+        return isChrome;
+    }
+
+// Function to hide buttons if not using a Chrome-based browser
+    function hideHidDeviceButtonsIfNotChromeBased() {
+        if (!isChromeBasedBrowser()) {
+            // Select the buttons you want to hide
+            const button1 = document.querySelector('.push-filters-todevice')
+            const button2 = document.querySelector('.pull-filters-fromdevice');
+
+            // Hide the buttons
+            button1.style.display = 'none';
+            button2.style.display = 'none';
+        }
+    }
+
+    hideHidDeviceButtonsIfNotChromeBased();
+});

--- a/style-alt.css
+++ b/style-alt.css
@@ -903,10 +903,15 @@ div.filters-button {
     gap: 0 4px;
 }
 
+
 div.extra-panel button.sort-filters,
 div.extra-panel button.readme {
     flex: calc(50% - 2px) 0 0;
     border-color: var(--background-color-contrast) !important;
+}
+div.extra-panel button.pull-filters-fromdevice,
+div.extra-panel button.push-filters-todevice {
+    flex: calc(50% - 2px) 0 0;
 }
 
 div.extra-panel button.import-filters,
@@ -914,6 +919,12 @@ div.extra-panel button.export-filters {
     position: relative;
     
     flex: 100% 0 0;
+}
+
+div.extra-panel button#connect-device-button {
+    flex: 100% 0 0;
+    display: block;
+    margin-top: 10px; /* Optional: add some space above the connect button */
 }
 
 button.export-graphic-filters {

--- a/usbHidConnector.js
+++ b/usbHidConnector.js
@@ -10,12 +10,17 @@ window.UsbHIDConnector = (function() {
 
     let devices = [];
 
+    // Handlers - code to handle the vendor specific implementation of the USBHID
     let deviceHandlers = {
         "FiiO": {
             "JadeAudio JA11": fiioUsbHID,
-            "FiiO KA17":     fiioUsbHID,
+            "FIIO KA17":  fiioUsbHID,
+            "FIIO Q7":    fiioUsbHID,
+            "FIIO BTR13": fiioUsbHID,
+            "FIIO KA15":  fiioUsbHID
+
         }
-        // Add more manufacturers and models here
+        // Add more manufacturers, models and then handlers here
     };
 
     let isWebHIDSupported = function () {
@@ -25,25 +30,25 @@ window.UsbHIDConnector = (function() {
 
     let getDeviceConnected = async function() {
         try {
-            const filters = [
-                {"vendorId": 10610, "manufacturer":"FiiO", "productNames":["JadeAudio JA11"]}  // FiiO - add more when I get more examples
+            const vendorToManufacturer = [
+                {"vendorId": 10610, "manufacturer":"FiiO"}  // FiiO - add more when I get more examples
             ];
 
             // Check if the device is already connected
-            let existingDevice = devices.find(d => d.rawDevice.vendorId === filters[0].vendorId);
+            let existingDevice = devices.find(d => d.rawDevice.vendorId === vendorToManufacturer[0].vendorId);
             if (existingDevice) {
                 console.log("Device already connected:", existingDevice.model);
                 return existingDevice;
             }
 
-            // Request devices matching the filters
-            const selectedDevices = await navigator.hid.requestDevice({ filters });
+            // Request devices matching the filters - only show supported devices in popup
+            const selectedDevices = await navigator.hid.requestDevice({ filters: vendorToManufacturer });
 
             if (selectedDevices.length > 0) {
                 // Select the first device and store it as the current device
                 const rawDevice = selectedDevices[0];
 
-                const manufacturer = filters[0].manufacturer;
+                const manufacturer = vendorToManufacturer[0].manufacturer;
                 const model = rawDevice.productName;    // Model == productName
 
                 console.log("Manufacturer:", manufacturer);

--- a/usbHidConnector.js
+++ b/usbHidConnector.js
@@ -1,0 +1,119 @@
+//
+// Copyright 2024 : Pragmatic Audio
+//
+// Declare UsbHIDConnector and attach it to the global window object
+window.UsbHIDConnector = (function() {
+
+    let config = {
+    };
+
+
+    let devices = [];
+
+    let deviceHandlers = {
+        "FiiO": {
+            "JadeAudio JA11": fiioUsbHID,
+            "FiiO KA17":     fiioUsbHID,
+        }
+        // Add more manufacturers and models here
+    };
+
+    let isWebHIDSupported = function () {
+        return 'hid' in navigator;
+    };
+
+
+    let getDeviceConnected = async function() {
+        try {
+            const filters = [
+                {"vendorId": 10610, "manufacturer":"FiiO", "productNames":["JadeAudio JA11"]}  // FiiO - add more when I get more examples
+            ];
+
+            // Check if the device is already connected
+            let existingDevice = devices.find(d => d.rawDevice.vendorId === filters[0].vendorId);
+            if (existingDevice) {
+                console.log("Device already connected:", existingDevice.model);
+                return existingDevice;
+            }
+
+            // Request devices matching the filters
+            const selectedDevices = await navigator.hid.requestDevice({ filters });
+
+            if (selectedDevices.length > 0) {
+                // Select the first device and store it as the current device
+                const rawDevice = selectedDevices[0];
+
+                const manufacturer = filters[0].manufacturer;
+                const model = rawDevice.productName;    // Model == productName
+
+                console.log("Manufacturer:", manufacturer);
+                console.log("Model:", model);
+
+                // Open the device if it's not already open
+                if (!rawDevice.opened) {
+                    await rawDevice.open()
+                } else {
+                    console.log("Device is already open:", currentDevice.model);
+                }
+                let currentDevice = {
+                    "rawDevice": rawDevice,
+                    "manufacturer": manufacturer,
+                    "model": model
+                }
+
+                // Store the device with its identified handler
+                devices.push(currentDevice);
+
+                return currentDevice;
+            } else {
+                console.log("No device found.");
+            }
+        } catch (error) {
+            console.error("Failed to connect to HID device:", error);
+
+        }
+    };
+
+    let connectToDevice = async function(device) {
+        const handler = getDeviceHandler(device);
+        if (!handler) {
+            console.error("Device handler not found for", device.manufacturerName, device.productName);
+            return;
+        }
+        await handler.connect(device.rawDevice);
+    };
+
+    let pushToDevice = async function(device, slot, preamp, fr) {
+        const handler = getDeviceHandler(device);
+        if (!handler) {
+            console.error("Device handler not found for", device.manufacturerName, device.productName);
+            return;
+        }
+        await handler.pushToDevice(device.rawDevice, slot, preamp, fr);
+    };
+
+    let pullFromDevice = async function(device, slot) {
+        const handler = getDeviceHandler(device);
+        if (!handler) {
+            console.error("Device handler not found for", device.manufacturerName, device.productName);
+            return;
+        }
+        return await handler.pullFromDevice(device.rawDevice, slot);
+    };
+
+    let getDeviceHandler = function(device) {
+        const manufacturer = device.manufacturer;
+        const model = device.model;
+        return deviceHandlers[manufacturer]?.[model];
+    };
+
+
+    return {
+        config,
+        isWebHIDSupported,
+        getDeviceConnected,
+        connectToDevice,
+        pushToDevice,
+        pullFromDevice
+    }
+})();


### PR DESCRIPTION
This is my initial version of this code which effectively does the following:
1. If the browser supports it (all Chromium based browsers have a USB HID API - but Safari and Firefox don't)
2. Add 2 buttons to Pull PEQ data from a registered / supported device into the Filters list and to Push PEQ data back to device.
3. Supports JA11 pretty well and I briefly tested KA17 (but there are still some bugs to fix) 
4. Designed to be easily extendable over time with hopefully more and more devices added to the supported list